### PR TITLE
Better readme and micro sample bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 dist
 node_modules
 yarn-error.log
+__pycache__
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 * Queues consecutive bot messages for better readability
 * Demo mode included (ideal for scripted screencasts)
 * Hosted on S3 for easy use
-* Includes a `BotServerChannel` for use with Rasa Core (under `rasa_utils`)
+* Includes a `BotServerChannel` for use with [Rasa Core](https://github.com/rasahq/rasa_core) (under `rasa_utils`)
 
 ## Usage
 
@@ -36,17 +36,33 @@
       container: document.querySelector(".chat-container"),
       welcomeMessage: "Hi, I am Mike. How may I help you?"
     });
+    chatroom.openChat();
   </script>
 </body>
 ```
 
-### Use BotServerChannel in a Rasa Core project
+### Basic usage
+
+* Clone repository
+* Install frontend dependencies `yarn install`
+* Build frontend files `yarn build`
+* Create an HTML page for your Chatroom (see usage example above or modify [index.html](./index.html))
+* Make sure to adjust the `host` option. Use `http://localhost:5002` when testing locally
+* Run `yarn serve` to launch a web server with your Chatroom on `http://localhost:8080`
+* Integrate with a Rasa Core project (see standard or custom project below)
+
+### Usage with a standard Rasa Core project
+
+* Copy `rasa_utils` to your project
+* Install the Python dependencies from `rasa_utils/requirements.txt`
+* Run your bot with `python -m rasa_utils.bot -d models/current/dialogue -u models/current/nlu_model`
+
+### Usage with a custom Rasa Core project
 
 * Copy the `rasa_utils/bot_server_channel.py` to your project
 * Install the Python dependencies from `rasa_utils/requirements.txt`
 * Register the `BotServerInputChannel` with your Rasa Core `Agent` (see below)
 * Run your bot. By default the server will be available at `0.0.0.0:5002`
-* When using the configuration above make sure the host has http://localhost:5002 if testing locally otherwise you will get errors when trying to test the chat.
 
 ```python
 from bot_server_channel import BotServerInputChannel
@@ -65,13 +81,13 @@ main_server()
 
 ## Development
 
-### Install Dependencies
+### Install dependencies
 
 ```
 yarn install
 ```
 
-### Build the Simple Chatroom
+### Continuously build the Chatroom component
 
 ```
 yarn watch

--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@
 * Copy `rasa_utils` to your project
 * Install the Python dependencies from `rasa_utils/requirements.txt`
 * Run your bot with `python -m rasa_utils.bot -d models/current/dialogue -u models/current/nlu_model`
+* The bot server will be available at `0.0.0.0:5002`
+
 
 ### Usage with a custom Rasa Core project
 
 * Copy the `rasa_utils/bot_server_channel.py` to your project
 * Install the Python dependencies from `rasa_utils/requirements.txt`
 * Register the `BotServerInputChannel` with your Rasa Core `Agent` (see below)
-* Run your bot. By default the server will be available at `0.0.0.0:5002`
+* Run your bot. By default the bot server will be available at `0.0.0.0:5002`
 
 ```python
 from bot_server_channel import BotServerInputChannel

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 * Copy `rasa_utils` to your project
 * Install the Python dependencies from `rasa_utils/requirements.txt`
-* Run your bot with `python -m rasa_utils.bot -d models/current/dialogue -u models/current/nlu_model`
+* Run your bot with `python -m rasa_utils.bot -d models/current/dialogue -u models/current/nlu`
 * The bot server will be available at `0.0.0.0:5002`
 
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 window.chatroom = new window.Chatroom({
   title: "Chat with a bot",
   container: document.querySelector(".chat-container"),
-  welcomeMessage: "Hi, I am Mike. Nice to meet you.",
+  welcomeMessage: "Nice to meet you.",
   host: "http://localhost:5002",
 });
 window.chatroom.openChat();

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ window.chatroom = new window.Chatroom({
   title: "Chat with a bot",
   container: document.querySelector(".chat-container"),
   welcomeMessage: "Hi, I am Mike. Nice to meet you.",
-  host: "https://mike.bots.scm.io",
+  host: "http://localhost:5002",
 });
 window.chatroom.openChat();
 </script>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@ window.chatroom = new window.Chatroom({
   welcomeMessage: "Hi, I am Mike. Nice to meet you.",
   host: "https://mike.bots.scm.io",
 });
+window.chatroom.openChat();
 </script>
   </body>
 </html>

--- a/rasa_utils/bot.py
+++ b/rasa_utils/bot.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+
+from .bot_server_channel import BotServerInputChannel
+
+from rasa_core.agent import Agent
+from rasa_core import utils
+
+
+def create_argparser():
+    parser = argparse.ArgumentParser(
+            description='starts the bot')
+
+    parser.add_argument(
+        '-d', '--core',
+        required=True,
+        type=str,
+        help="core model to run")
+
+    parser.add_argument(
+        '-u', '--nlu',
+        type=str,
+        help="nlu model to run")
+
+    parser.add_argument(
+        '-p', '--port',
+        default=5002,
+        type=int,
+        help="port to run the server at")
+
+    parser.add_argument(
+        '-o', '--log_file',
+        type=str,
+        default="rasa_core.log",
+        help="store log file in specified file")
+
+    utils.add_logging_option_arguments(parser)
+    return parser
+
+
+def preprocessor(message_text):
+    text = message_text.strip()
+    return text
+
+
+if __name__ == "__main__":
+
+    parser = create_argparser()
+    cmdline_args = parser.parse_args()
+
+    utils.configure_colored_logging(cmdline_args.loglevel)
+    utils.configure_file_logging(cmdline_args.loglevel,
+                                 cmdline_args.log_file)
+
+    agent = Agent.load(cmdline_args.core, cmdline_args.nlu)
+    channel = BotServerInputChannel(agent, port=cmdline_args.port)
+    agent.handle_channel(channel, message_preprocessor=preprocessor)

--- a/rasa_utils/requirements.txt
+++ b/rasa_utils/requirements.txt
@@ -1,2 +1,3 @@
 klein
 twisted
+rasa_core


### PR DESCRIPTION
Adds an example bot that can be run like standard Rasa Core:

```
python -m rasa_utils.bot -d models/current/dialogue -u models/current/nlu_model
```

Also adds more descriptions on how to actually use the Chatroom component when getting started.
