### PR TITLE
deactivate buttons for old messages

### DIFF
--- a/src/Chatroom.js
+++ b/src/Chatroom.js
@@ -61,7 +61,7 @@ type ChatroomProps = {
   messages: Array<ChatMessage>,
   title: string,
   isOpen: boolean,
-  showWaitingBubble: boolean,
+  waitingForBotResponse: boolean,
   speechRecognition: ?string,
   onButtonClick: (message: string, payload: string) => *,
   onSendMessage: (message: string) => *,
@@ -186,8 +186,10 @@ export default class Chatroom extends Component<ChatroomProps, ChatroomState> {
   };
 
   render() {
-    const { messages, isOpen, showWaitingBubble } = this.props;
+    const { messages, isOpen, waitingForBotResponse } = this.props;
     const messageGroups = this.groupMessages(messages);
+    const isClickable = i =>
+      !waitingForBotResponse && i == messageGroups.length - 1;
 
     return (
       <div className={classnames("chatroom", isOpen ? "open" : "closed")}>
@@ -197,10 +199,12 @@ export default class Chatroom extends Component<ChatroomProps, ChatroomState> {
             <MessageGroup
               messages={group}
               key={i}
-              onButtonClick={this.handleButtonClick}
+              onButtonClick={
+                isClickable(i) ? this.handleButtonClick : undefined
+              }
             />
           ))}
-          {showWaitingBubble ? <WaitingBubble /> : null}
+          {waitingForBotResponse ? <WaitingBubble /> : null}
         </div>
         <form className="input" onSubmit={this.handleSubmitMessage}>
           <input

--- a/src/Chatroom.scss
+++ b/src/Chatroom.scss
@@ -1,6 +1,7 @@
 $backgroundColor: rgba(200, 200, 200, 0.9);
 $chromeColor: rgba(52, 61, 78, 1);
 $chromeColor2: white;
+$chromeColor3: grey;
 $bubbleColor: rgba(255, 255, 255, 0.8);
 $textColor: rgba(52, 61, 78, 1);
 $linkColor: #3498db;
@@ -175,6 +176,10 @@ $linkColor: #3498db;
         &.chat-button-selected {
           background-color: rgba($chromeColor, 0.6);
           color: $chromeColor2;
+        }
+        &.chat-button-disabled {
+          color: $chromeColor3;
+          border: 2px solid $chromeColor3;
         }
       }
     }

--- a/src/ConnectedChatroom.js
+++ b/src/ConnectedChatroom.js
@@ -256,7 +256,7 @@ export default class ConnectedChatroom extends Component<
       <Chatroom
         messages={renderableMessages}
         title={this.props.title}
-        showWaitingBubble={waitingForBotResponse}
+        waitingForBotResponse={waitingForBotResponse}
         isOpen={this.state.isOpen}
         speechRecognition={this.props.speechRecognition}
         onToggleChat={this.handleToggleChat}

--- a/src/Message.js
+++ b/src/Message.js
@@ -39,7 +39,8 @@ const Message = ({ chat, onButtonClick }: MessageProps) => {
           {message.buttons.map(({ payload, title, selected }) => (
             <li
               className={classnames("chat-button", {
-                "chat-button-selected": selected
+                "chat-button-selected": selected,
+                "chat-button-disabled": !onButtonClick
               })}
               key={payload}
               onClick={

--- a/src/Message.js
+++ b/src/Message.js
@@ -27,7 +27,7 @@ export const MessageTime = ({ time, isBot }: MessageTimeProps) => {
 
 type MessageProps = {
   chat: ChatMessage,
-  onButtonClick: (title: string, payload: string) => void
+  onButtonClick?: (title: string, payload: string) => void
 };
 const Message = ({ chat, onButtonClick }: MessageProps) => {
   const message = chat.message;
@@ -42,7 +42,9 @@ const Message = ({ chat, onButtonClick }: MessageProps) => {
                 "chat-button-selected": selected
               })}
               key={payload}
-              onClick={() => onButtonClick(title, payload)}
+              onClick={
+                onButtonClick ? () => onButtonClick(title, payload) : undefined
+              }
             >
               <Markdown
                 source={title}

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ window.DemoChatroom = function(options: DemoChatroomOptions) {
     this.ref = ReactDOM.render(
       <Chatroom
         messages={messages}
-        showWaitingBubble={showWaitingBubble}
+        waitingForBotResponse={showWaitingBubble}
         speechRecognition={null}
         isOpen={true}
         title={options.title || "Chat"}


### PR DESCRIPTION
Previously message-buttons could be clicked multiple times, or when the user already sent another message. This was especially a problem with users that double-clicked on the buttons. This PR resolves this (fixes #64).