### PR TITLE
Add feature to disable input when last message type is a button

### DIFF
--- a/src/Chatroom.js
+++ b/src/Chatroom.js
@@ -63,6 +63,7 @@ type ChatroomProps = {
   isOpen: boolean,
   waitingForBotResponse: boolean,
   speechRecognition: ?string,
+  disableInputOnButton: ?boolean,
   onButtonClick: (message: string, payload: string) => *,
   onSendMessage: (message: string) => *,
   onToggleChat: () => *
@@ -186,10 +187,12 @@ export default class Chatroom extends Component<ChatroomProps, ChatroomState> {
   };
 
   render() {
-    const { messages, isOpen, waitingForBotResponse } = this.props;
+    const { messages, isOpen, waitingForBotResponse, disableInputOnButton } = this.props;
     const messageGroups = this.groupMessages(messages);
     const isClickable = i =>
       !waitingForBotResponse && i == messageGroups.length - 1;
+	const isInputDisabled = () =>
+	  messageGroups[messageGroups.length-1][0].message.type === "button";
 
     return (
       <div className={classnames("chatroom", isOpen ? "open" : "closed")}>
@@ -209,6 +212,9 @@ export default class Chatroom extends Component<ChatroomProps, ChatroomState> {
         <form className="input" onSubmit={this.handleSubmitMessage}>
           <input
             type="text"
+            disabled={
+              disableInputOnButton ? isInputDisabled() : false
+            }
             value={this.state.inputValue}
             onChange={event =>
               this.handleInputChange(event.currentTarget.value)

--- a/src/Chatroom.scss
+++ b/src/Chatroom.scss
@@ -216,6 +216,10 @@ $linkColor: #3498db;
         box-shadow: none;
         background-color: white;
       }
+	    &:disabled {
+        background-color: grey;
+        cursor: not-allowed;
+	    }
     }
 
     input[type="submit"] {

--- a/src/ConnectedChatroom.js
+++ b/src/ConnectedChatroom.js
@@ -14,6 +14,7 @@ type ConnectedChatroomProps = {
   waitingTimeout: number,
   pollingInterval: number,
   speechRecognition: ?string,
+  disableInputOnButton: ?boolean,
   messageBlacklist: Array<string>,
   fetchOptions?: RequestOptions
 };
@@ -259,6 +260,7 @@ export default class ConnectedChatroom extends Component<
         waitingForBotResponse={waitingForBotResponse}
         isOpen={this.state.isOpen}
         speechRecognition={this.props.speechRecognition}
+        disableInputOnButton={this.props.disableInputOnButton}
         onToggleChat={this.handleToggleChat}
         onButtonClick={this.handleButtonClick}
         onSendMessage={this.sendMessage}

--- a/src/DebuggerView.js
+++ b/src/DebuggerView.js
@@ -26,6 +26,7 @@ type DebuggerViewProps = {
   waitingTimeout?: number,
   pollingInterval?: number,
   speechRecognition: ?string,
+  disableInputOnButton: ?boolean,
   messageBlacklist?: Array<string>,
   fetchOptions?: RequestOptions
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ type ChatroomOptions = {
   title?: string,
   welcomeMessage?: string,
   speechRecognition?: string,
+  disableInputOnButton?: boolean,
   startMessage?: string,
   container: HTMLElement,
   waitingTimeout?: number,
@@ -41,6 +42,7 @@ window.Chatroom = function(options: ChatroomOptions) {
       host={options.host}
       title={options.title || "Chat"}
       speechRecognition={options.speechRecognition}
+      disableInputOnButton={options.disableInputOnButton}
       welcomeMessage={options.welcomeMessage}
       waitingTimeout={options.waitingTimeout}
       pollingInterval={options.pollingInterval}
@@ -75,6 +77,7 @@ window.DemoChatroom = function(options: DemoChatroomOptions) {
         messages={messages}
         waitingForBotResponse={showWaitingBubble}
         speechRecognition={null}
+        disableInputOnButton={false}
         isOpen={true}
         title={options.title || "Chat"}
         onButtonClick={noop}
@@ -205,6 +208,7 @@ window.DebugChatroom = function(options: ChatroomOptions) {
       host={options.host}
       title={options.title || "Chat"}
       speechRecognition={options.speechRecognition}
+      disableInputOnButton={options.disableInputOnButton}
       welcomeMessage={options.welcomeMessage}
       waitingTimeout={options.waitingTimeout}
       pollingInterval={options.pollingInterval}


### PR DESCRIPTION
* Added a new prop "disableInputOnButton" - If true, then we will disable text input if last bot message type is a button, and add corresponding css style to show "not-allowed".

Based on https://github.com/scalableminds/chatroom/issues/87