### PR TITLE
rasa documentation supports a single response with both a text type a…

### DIFF
--- a/src/ConnectedChatroom.js
+++ b/src/ConnectedChatroom.js
@@ -127,9 +127,26 @@ export default class ConnectedChatroom extends Component<
   async parseMessages(RasaMessages: Array<RasaMessage>) {
     const validMessageTypes = ["text", "image", "buttons", "attachment"];
 
-    const messages = RasaMessages.filter((message: RasaMessage) =>
+    let expandedMessages = [];
+
+    const originalMessages = RasaMessages.filter((message: RasaMessage) =>
       validMessageTypes.some(type => type in message),
     ).map((message: RasaMessage) => {
+      if (message.text && message.buttons){
+
+        const textMessage = {...message}
+        delete textMessage.buttons;
+
+        const buttonsMessage = {...message}
+        delete buttonsMessage.text;
+
+        expandedMessages.push(textMessage);
+        expandedMessages.push(buttonsMessage);
+
+      } else {expandedMessages.push(message)}
+    })
+
+    const messages = expandedMessages.map((message: RasaMessage) => {
       let botMessageObj;
       if (message.text) botMessageObj = { type: "text", text: message.text };
 


### PR DESCRIPTION
rasa documentation supports a single response with both a text type and a button type. This commit creates two chat messages for any entry in the messages array that has both a text and button component.

from https://github.com/RasaHQ/rasa-demo/blob/master/domain.yml

```  utter_ask_feedback:
    - text: "How is this conversation going?"
      buttons:
        - title: "👍"
          payload: "/feedback{\"feedback_value\":\"positive\"}"
        - title: "👎"
          payload: "/feedback{\"feedback_value\":\"negative\"}"
```

Fixes #111 