### PR TITLE
Fix fetchOptions prop

### DIFF
--- a/src/ConnectedChatroom.js
+++ b/src/ConnectedChatroom.js
@@ -118,13 +118,13 @@ export default class ConnectedChatroom extends Component<
       sender: this.props.userId
     };
 
-    const fetchOptions = Object.assign({}, this.props.fetchOptions, {
+    const fetchOptions = Object.assign({}, {
       method: "POST",
       body: JSON.stringify(rasaMessageObj),
       headers: {
         "Content-Type": "application/json"
       }
-    });
+    }, this.props.fetchOptions);
 
     const response = await fetch(
       `${this.props.host}/webhooks/rest/webhook`,


### PR DESCRIPTION
Fixed bug where it was not possible to pass your own headers to request with "**fetchOptions**" prop.
Just changed the order the _Object.assign_ works on _ConnectedChatroom.js_ so that we are able to rewrite our own request headers if needed.