### PR TITLE
[FIX] TTS API

### DIFF
--- a/src/Message.js
+++ b/src/Message.js
@@ -34,13 +34,28 @@ type MessageProps = {
 
 const supportSpeechSynthesis = () => "SpeechSynthesisUtterance" in window;
 
-const speak = (message: string, voiceLang: string) => {
+const getVoices = () => new Promise(resolve => {
+  let voices = speechSynthesis.getVoices();
+  if (voices.length) {
+    resolve(voices);
+    return;
+  }
+  speechSynthesis.onvoiceschanged = () => {
+    voices = speechSynthesis.getVoices();
+    resolve(voices);
+  }
+});
+
+
+const speak = async (message: string, voiceLang: string) => {
   const synth = window.speechSynthesis;
-  let voices = [];
-  voices = synth.getVoices();
+  const voices = await getVoices();
   const toSpeak = new SpeechSynthesisUtterance(message);
-  toSpeak.voice = voices.find(voice => voice.lang === voiceLang);
-  synth.speak(toSpeak);
+  const desiredVoice = voices.find(voice => voice.lang === voiceLang);
+  if (desiredVoice) {
+    toSpeak.voice = desiredVoice;
+    synth.speak(toSpeak);
+  }
 };
 
 const Message = ({ chat, onButtonClick, voiceLang = null }: MessageProps) => {


### PR DESCRIPTION
Related Issue: https://github.com/scalableminds/chatroom/issues/122

This changes the expected behavior of TTS. Now it will only trigger TTS when the passed `voiceLang` matches the supported languages by [SpeechSynthesis API](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/getVoices).